### PR TITLE
fix: set white as default header color

### DIFF
--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -10,9 +10,9 @@
 	/* color to provide a visual clue to differ
 	 a staging/test or production environment */
 	const color =
-		$page.url.hostname.includes('integ') || $page.url.hostname.includes('localhost')
-			? '#ffa500'
-			: '#FFFFFF';
+		$page.url.hostname.includes('data.stadt')
+			? '#FFFFFF'
+			: '#ffa500';
 </script>
 
 <header class="layout_wrapper">


### PR DESCRIPTION
If set the other way, we would see an orange flash when reloading