### PR TITLE
fix: Set isStaging to true only when on INTEG, not local

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -2,7 +2,7 @@
 	import type { Load } from '@sveltejs/kit';
 
 	export const load: Load = ({ url }) => {
-		const isStaging = url.hostname.includes('integ') || url.hostname.includes('localhost');
+		const isStaging = url.hostname.includes('integ');
 		return {
 			props: {
 				isStaging


### PR DESCRIPTION
On the server, we run the app on localhost:3000 and proxy it via Apache. This is what causes the orange flicker:
at first, isStaging is set to true because the url contains localhost, and then it is set to false once
the PROD url kicks in.