### PR TITLE
fix: center text in download button

### DIFF
--- a/src/lib/DatasetResources.svelte
+++ b/src/lib/DatasetResources.svelte
@@ -38,7 +38,9 @@
 	}
 
 	.download {
-		padding-top: 1rem;
+		padding: 0.25em 0.5em;
+		margin-right: 0.25em;
+		margin-top: 0.25em;
 	}
 
 	@media (min-width: 800px) {


### PR DESCRIPTION
this button was not centered in the microsoft edge browser
the css form the tag button that works fine also in the edge
browser was copied to be used also for this download button