### PR TITLE
fix: improve placeholder text for search input in header bar

### DIFF
--- a/src/lib/HeaderBar.svelte
+++ b/src/lib/HeaderBar.svelte
@@ -49,7 +49,7 @@
 								type="text"
 								class="text"
 								name="q"
-								placeholder="Suche"
+								placeholder="Datensätze suchen..."
 								autocomplete="off"
 							/>
 						</form>


### PR DESCRIPTION
adapt it to the search input placeholder text on the homepage